### PR TITLE
remove need for magic numbers in resizing code

### DIFF
--- a/src/treemendous.py
+++ b/src/treemendous.py
@@ -174,13 +174,7 @@ class VisualViewDialog(wx.Dialog):
         event.Skip()
 
     def OnSize(self, event):
-        (dialogWidth, dialogHeight) = self.GetSize()
-        if self.platform not in ("Windows", "Darwin"):
-            # magic numbers are needed to make sure the image doesn't go outside the bounds of the dialog window
-            dialogWidthAdjust = -50
-            dialogHeightAdjust = -90
-            dialogWidth += dialogWidthAdjust
-            dialogHeight += dialogHeightAdjust
+        (dialogWidth, dialogHeight) = self.GetClientSize()
         dialogProportion = dialogWidth / dialogHeight
         if dialogProportion > self.imgProportion:
             newHeight = dialogHeight


### PR DESCRIPTION
Now using GetClientSize() instead of GetSize() to avoid inclusion of window decorations in initial window size calculations for visual display of tree.

Tested on Linux and Windows.